### PR TITLE
Improved camera controller, added center camera action, started on ledge get up transition

### DIFF
--- a/Assets/Camera/CameraFreeStrategyQuat.cs
+++ b/Assets/Camera/CameraFreeStrategyQuat.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TCS
+{
+    public class CameraFreeStrategyQuat : CameraStrategy
+    {
+
+        public override void ExecuteStrategyLateUpdate(PlayerCameraController camControl)
+        {
+            float dt = Time.deltaTime * 60f;
+
+            // updates position.
+            Follow(camControl);
+
+            // Grabs Left Stick and Mouse Movement Inputs.
+            float h = InputManager.getCameraX();
+            float v = InputManager.getCameraY();
+
+            float rotX = v * camControl.rotXSpeed * dt;
+            float rotY = h * camControl.rotYSpeed * dt;
+            rotX = Mathf.Clamp(rotX, camControl.rotXmin, camControl.rotXmax);
+
+
+            Transform camHolder = ((PlayerCameraControllerQuat) camControl).camHolder;
+
+            // add the rotation input to the camera's rotation
+            // multiplication of Quaternions is like adding euler angles.
+            Quaternion newRotation = 
+                camHolder.localRotation 
+                * Quaternion.Euler(v * camControl.rotXSpeed * dt, h * camControl.rotYSpeed * dt, 0);
+
+            // I'm not 100% sure why the previous Quaternion.Euler(...) makes a Quaternion with nonzero euler z value
+            // So this zeroes out the z rotation. 
+            newRotation = Quaternion.Euler(newRotation.eulerAngles.x, newRotation.eulerAngles.y, 0);
+
+            camHolder.localRotation = newRotation;
+        }
+
+        public void Follow(PlayerCameraController camControl)
+        {
+            float dt = Time.deltaTime * 60f;
+
+            Vector3 currentPosition = camControl.transform.position;
+            Vector3 targetPosition = camControl.followTarget.position;
+
+            float newX = Mathf.Lerp(currentPosition.x, targetPosition.x, (1/ camControl.getXZDamp()) * dt);
+            float newZ = Mathf.Lerp(currentPosition.z, targetPosition.z, (1 / camControl.getXZDamp()) * dt);
+            float newY = Mathf.Lerp(currentPosition.y, targetPosition.y, (1 / camControl.getYDamp()) * dt);
+
+            camControl.transform.position = new Vector3(newX, newY, newZ);
+        }
+    }
+}

--- a/Assets/Camera/CameraFreeStrategyQuat.cs.meta
+++ b/Assets/Camera/CameraFreeStrategyQuat.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b42fe39a669c164e8a36771909e322c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Camera/CameraTargetStrategy.cs
+++ b/Assets/Camera/CameraTargetStrategy.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TCS
+{
+    public class CameraTargetStrategy : CameraStrategy
+    {
+
+        private Quaternion targetRotation;
+        private float progress;
+        public void SetTargetRotation(Quaternion rot, PlayerCameraController camControl) {
+            targetRotation = Quaternion.RotateTowards(camControl.transform.rotation, rot, 1);
+            camControl.rotXTar = targetRotation.eulerAngles.x;
+            camControl.rotYTar = targetRotation.eulerAngles.y;
+            
+        }
+
+        public CameraTargetStrategy(Quaternion targetRotation, PlayerCameraController camControl) {
+            SetTargetRotation(targetRotation, camControl);
+        }
+
+        public override void ExecuteStrategyLateUpdate(PlayerCameraController camControl)
+        {
+            Follow(camControl);
+
+            progress += Time.deltaTime * camControl.targetSpeed;
+            if (progress > 1) progress = 1;
+
+            
+            float lerpedRotX = Mathf.Lerp(
+                    camControl.camX.localRotation.y, 
+                    camControl.rotYTar, 
+                    progress);
+            float lerpedRotY = Mathf.Lerp(
+                    camControl.camY.localRotation.x, 
+                    camControl.rotXTar, 
+                    progress);
+
+
+            // uses Euler to set the transform rotation.
+            camControl.camX.localRotation = Quaternion.Euler(
+                0, 
+                lerpedRotX,
+                0);
+                
+            camControl.camY.localRotation = Quaternion.Euler(
+                lerpedRotY,
+                0,
+                0);
+
+
+            if (progress >= 1) {
+                
+                // we've finished pointing the camera where we wanted to
+                camControl.SetStrategy(new CameraFreeStrategy());
+                Debug.Log("Free camera");
+            }
+        }
+
+        public void Follow(PlayerCameraController camControl)
+        {
+            float dt = Time.deltaTime * 60f;
+
+            Vector3 currentPosition = camControl.transform.position;
+            Vector3 targetPosition = camControl.followTarget.position;
+
+            float newX = Mathf.Lerp(currentPosition.x, targetPosition.x, (1/ camControl.getXZDamp()) * dt);
+            float newZ = Mathf.Lerp(currentPosition.z, targetPosition.z, (1 / camControl.getXZDamp()) * dt);
+            float newY = Mathf.Lerp(currentPosition.y, targetPosition.y, (1 / camControl.getYDamp()) * dt);
+
+            camControl.transform.position = new Vector3(newX, newY, newZ);
+        }
+    }
+}

--- a/Assets/Camera/CameraTargetStrategy.cs.meta
+++ b/Assets/Camera/CameraTargetStrategy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 875e4c3a6e19467478c36f9f94f545f8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Camera/CameraTargetStrategyQuat.cs
+++ b/Assets/Camera/CameraTargetStrategyQuat.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TCS
+{
+    public class CameraTargetStrategyQuat : CameraStrategy
+    {
+
+        private Quaternion targetRotation;
+        private Quaternion startRotation;
+        private float progress;
+        public void SetTargetRotation(Quaternion targetRot, PlayerCameraControllerQuat camControl) {
+            startRotation = camControl.camHolder.rotation;
+            targetRotation = targetRot;            
+        }
+
+        public CameraTargetStrategyQuat(Quaternion targetRotation, PlayerCameraControllerQuat camControl) {
+            SetTargetRotation(targetRotation, camControl);
+        }
+
+        public override void ExecuteStrategyLateUpdate(PlayerCameraController camControl)
+        {
+            Follow(camControl);
+
+            PlayerCameraControllerQuat controller = ((PlayerCameraControllerQuat) camControl);
+
+            progress += Time.deltaTime * camControl.targetSpeed;
+            float evaluation = controller.targetSwingCurve.Evaluate(progress);
+            if (progress > 1) progress = 1;
+
+            Transform camHolder = controller.camHolder;
+
+            Quaternion newRotation = Quaternion.Slerp(camHolder.rotation, targetRotation, evaluation);
+            camHolder.rotation = newRotation;
+
+
+            if (progress >= 1) {
+                
+                // we've finished pointing the camera where we wanted to
+                camControl.SetStrategy(new CameraFreeStrategyQuat());
+                Debug.Log("Free camera");
+                progress = 0;
+            }
+        }
+
+        public void Follow(PlayerCameraController camControl)
+        {
+            float dt = Time.deltaTime * 60f;
+
+            Vector3 currentPosition = camControl.transform.position;
+            Vector3 targetPosition = camControl.followTarget.position;
+
+            float newX = Mathf.Lerp(currentPosition.x, targetPosition.x, (1/ camControl.getXZDamp()) * dt);
+            float newZ = Mathf.Lerp(currentPosition.z, targetPosition.z, (1 / camControl.getXZDamp()) * dt);
+            float newY = Mathf.Lerp(currentPosition.y, targetPosition.y, (1 / camControl.getYDamp()) * dt);
+
+            camControl.transform.position = new Vector3(newX, newY, newZ);
+        }
+    }
+}

--- a/Assets/Camera/CameraTargetStrategyQuat.cs.meta
+++ b/Assets/Camera/CameraTargetStrategyQuat.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dfc1f810f824fe04dae5ad279e050c1a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Camera/Player Camera Controller Quaternion.prefab
+++ b/Assets/Camera/Player Camera Controller Quaternion.prefab
@@ -1,0 +1,200 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1192843364073676
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4166362044207714}
+  - component: {fileID: 20863581749487140}
+  - component: {fileID: 124828238377321558}
+  - component: {fileID: 81959900124151536}
+  - component: {fileID: 45096408640067850}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4166362044207714
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1192843364073676}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: -1}
+  m_LocalPosition: {x: 0, y: 1.5, z: -4.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1766674334707518686}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
+--- !u!20 &20863581749487140
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1192843364073676}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_GateFitMode: 2
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!124 &124828238377321558
+Behaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1192843364073676}
+  m_Enabled: 1
+--- !u!81 &81959900124151536
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1192843364073676}
+  m_Enabled: 1
+--- !u!45 &45096408640067850
+Skybox:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1192843364073676}
+  m_Enabled: 1
+  m_CustomSkybox: {fileID: 0}
+--- !u!1 &1677504909021614
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4845291897767944}
+  - component: {fileID: 5634951337059987213}
+  m_Layer: 0
+  m_Name: Player Camera Controller Quaternion
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4845291897767944
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1677504909021614}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -27}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1766674334707518686}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5634951337059987213
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1677504909021614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3c70e7423e8b35546a72ef193604d5e9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  xzDamping: 10
+  yDamping: 10
+  followTarget: {fileID: 0}
+  camX: {fileID: 0}
+  camY: {fileID: 0}
+  camZoom: {fileID: 0}
+  rotX: 0
+  rotY: 0
+  rotXTar: 0
+  rotYTar: 0
+  rotXmax: 65
+  rotXmin: -20
+  rotXSpeed: 2
+  rotYSpeed: 2
+  targetSpeed: 10
+  camHolder: {fileID: 1766674334707518686}
+  targetSwingCurve:
+    serializedVersion: 2
+    m_Curve: []
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+--- !u!1 &3333207767418226208
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1766674334707518686}
+  m_Layer: 0
+  m_Name: CamHolder
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1766674334707518686
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3333207767418226208}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4166362044207714}
+  m_Father: {fileID: 4845291897767944}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Camera/Player Camera Controller Quaternion.prefab.meta
+++ b/Assets/Camera/Player Camera Controller Quaternion.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6b108b2a65721cd4aa4daca9f45bab77
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Camera/PlayerCameraController.cs
+++ b/Assets/Camera/PlayerCameraController.cs
@@ -26,7 +26,7 @@ namespace TCS
         [HideInInspector]
         public CameraStrategy camStrat;
         [HideInInspector]
-        private Camera cam;
+        protected Camera cam;
 
         [HideInInspector]
         public float rotX;
@@ -44,6 +44,7 @@ namespace TCS
         public float rotXSpeed = 2;
         [HideInInspector]
         public float rotYSpeed = 2;
+        public float targetSpeed;
 
         #endregion
         
@@ -66,6 +67,10 @@ namespace TCS
 
         private void LateUpdate()
         {
+            if (Input.GetButtonDown("Fire1")) {
+                SetStrategy(new CameraTargetStrategy(followTarget.GetChild(0).rotation, this));
+            }
+
             if (camStrat != null) camStrat.ExecuteStrategyLateUpdate(this);
         }
 

--- a/Assets/Camera/PlayerCameraController.cs
+++ b/Assets/Camera/PlayerCameraController.cs
@@ -66,7 +66,7 @@ namespace TCS
 
         private void LateUpdate()
         {
-            camStrat.ExecuteStrategyLateUpdate(this);
+            if (camStrat != null) camStrat.ExecuteStrategyLateUpdate(this);
         }
 
         public void SetStrategy(CameraStrategy cameraStrategy)

--- a/Assets/Camera/PlayerCameraControllerQuat.cs
+++ b/Assets/Camera/PlayerCameraControllerQuat.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TCS
+{
+    public class PlayerCameraControllerQuat : PlayerCameraController
+    {
+
+        #region variables
+
+        public Transform camHolder;
+        public AnimationCurve targetSwingCurve;
+
+        #endregion
+        
+        // Use this for initialization
+        void Start()
+        {
+            // start with free cam
+            camStrat = new CameraFreeStrategyQuat();
+
+            camHolder = transform.GetChild(0);
+            cam = camHolder.GetComponent<Camera>();
+
+        }
+
+        private void LateUpdate()
+        {
+            if (Input.GetButtonDown("Fire1")) {
+                SetStrategy(new CameraTargetStrategyQuat(followTarget.GetChild(0).rotation, this));
+            }
+
+            if (camStrat != null) camStrat.ExecuteStrategyLateUpdate(this);
+        }
+    }
+}

--- a/Assets/Camera/PlayerCameraControllerQuat.cs.meta
+++ b/Assets/Camera/PlayerCameraControllerQuat.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 3c70e7423e8b35546a72ef193604d5e9
+timeCreated: 1521742569
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Misc/Utility.cs
+++ b/Assets/Misc/Utility.cs
@@ -66,13 +66,22 @@ namespace TCS
         }
     }
 
-    public class PointNormalPair {
+    public class PointNormalActionTypeTuple {
         public Vector3 point;
         public Vector3 normal;
+        public ClimbingContextualActionType actionType;
 
-        public PointNormalPair(Vector3 p, Vector3 n) {
+        public PointNormalActionTypeTuple(Vector3 p, Vector3 n, ClimbingContextualActionType type) {
             point = p;
             normal  = n;
+            actionType = type;
         }
     }
+
+    public enum ClimbingContextualActionType {
+        CLIMBING,
+        CLIMBUP,
+        CLIMBDOWN
+    }
+
 }

--- a/Assets/_Kyle/Characters/Protag/ProtagController v3.controller
+++ b/Assets/_Kyle/Characters/Protag/ProtagController v3.controller
@@ -14,61 +14,67 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: horizontal
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: vertical
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: grounded
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: fall
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: jump
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: compression
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: land
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: aerial direction
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: climbing
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
+  - m_Name: climbUp
+    m_Type: 1
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -481,6 +487,108 @@ BlendTree:
   m_UseAutomaticThresholds: 1
   m_NormalizedBlendValues: 0
   m_BlendType: 0
+--- !u!206 &206659735963976546
+BlendTree:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BlendTree
+  m_Childs: []
+  m_BlendParameter: movementMagnitude
+  m_BlendParameterY: movementMagnitude
+  m_MinThreshold: 0
+  m_MaxThreshold: 1
+  m_UseAutomaticThresholds: 1
+  m_NormalizedBlendValues: 0
+  m_BlendType: 0
+--- !u!206 &206692708424922710
+BlendTree:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: ClimbingMovement
+  m_Childs:
+  - serializedVersion: 2
+    m_Motion: {fileID: 7400004, guid: 489b5c4bb49b55248b51cd974046fba5, type: 3}
+    m_Threshold: 0
+    m_Position: {x: 0, y: 0}
+    m_TimeScale: 1
+    m_CycleOffset: 0
+    m_DirectBlendParameter: movementMagnitude
+    m_Mirror: 0
+  - serializedVersion: 2
+    m_Motion: {fileID: 7400002, guid: a5a41eb454bd4124480bd9cf91ca0115, type: 3}
+    m_Threshold: 0.125
+    m_Position: {x: 0.35, y: 0.35}
+    m_TimeScale: 1
+    m_CycleOffset: 0
+    m_DirectBlendParameter: movementMagnitude
+    m_Mirror: 0
+  - serializedVersion: 2
+    m_Motion: {fileID: 7400004, guid: a5a41eb454bd4124480bd9cf91ca0115, type: 3}
+    m_Threshold: 0.25
+    m_Position: {x: 0.5, y: 0}
+    m_TimeScale: 1
+    m_CycleOffset: 0
+    m_DirectBlendParameter: movementMagnitude
+    m_Mirror: 0
+  - serializedVersion: 2
+    m_Motion: {fileID: 7400006, guid: a5a41eb454bd4124480bd9cf91ca0115, type: 3}
+    m_Threshold: 0.375
+    m_Position: {x: 0.35, y: -0.35}
+    m_TimeScale: 1
+    m_CycleOffset: 0
+    m_DirectBlendParameter: movementMagnitude
+    m_Mirror: 0
+  - serializedVersion: 2
+    m_Motion: {fileID: 7400056, guid: a5a41eb454bd4124480bd9cf91ca0115, type: 3}
+    m_Threshold: 0.5
+    m_Position: {x: 0, y: -0.5}
+    m_TimeScale: 1
+    m_CycleOffset: 0
+    m_DirectBlendParameter: movementMagnitude
+    m_Mirror: 0
+  - serializedVersion: 2
+    m_Motion: {fileID: 7400058, guid: a5a41eb454bd4124480bd9cf91ca0115, type: 3}
+    m_Threshold: 0.625
+    m_Position: {x: -0.35, y: -0.35}
+    m_TimeScale: 1
+    m_CycleOffset: 0
+    m_DirectBlendParameter: movementMagnitude
+    m_Mirror: 0
+  - serializedVersion: 2
+    m_Motion: {fileID: 7400060, guid: a5a41eb454bd4124480bd9cf91ca0115, type: 3}
+    m_Threshold: 0.75
+    m_Position: {x: -0.5, y: 0}
+    m_TimeScale: 1
+    m_CycleOffset: 0
+    m_DirectBlendParameter: movementMagnitude
+    m_Mirror: 0
+  - serializedVersion: 2
+    m_Motion: {fileID: 7400016, guid: a5a41eb454bd4124480bd9cf91ca0115, type: 3}
+    m_Threshold: 0.875
+    m_Position: {x: -0.35, y: 0.35}
+    m_TimeScale: 1
+    m_CycleOffset: 0
+    m_DirectBlendParameter: movementMagnitude
+    m_Mirror: 0
+  - serializedVersion: 2
+    m_Motion: {fileID: 7400064, guid: a5a41eb454bd4124480bd9cf91ca0115, type: 3}
+    m_Threshold: 1
+    m_Position: {x: 0, y: 0.5}
+    m_TimeScale: 1
+    m_CycleOffset: 0
+    m_DirectBlendParameter: movementMagnitude
+    m_Mirror: 0
+  m_BlendParameter: horizontal
+  m_BlendParameterY: vertical
+  m_MinThreshold: 0
+  m_MaxThreshold: 1
+  m_UseAutomaticThresholds: 1
+  m_NormalizedBlendValues: 0
+  m_BlendType: 2
 --- !u!206 &206712803829767226
 BlendTree:
   m_ObjectHideFlags: 3
@@ -557,14 +665,6 @@ BlendTree:
     m_Motion: {fileID: 7400064, guid: a5a41eb454bd4124480bd9cf91ca0115, type: 3}
     m_Threshold: 15
     m_Position: {x: 0, y: 0.5}
-    m_TimeScale: 1
-    m_CycleOffset: 0
-    m_DirectBlendParameter: movementMagnitude
-    m_Mirror: 0
-  - serializedVersion: 2
-    m_Motion: {fileID: 206451183691727238}
-    m_Threshold: 0
-    m_Position: {x: 0, y: 0}
     m_TimeScale: 1
     m_CycleOffset: 0
     m_DirectBlendParameter: movementMagnitude
@@ -700,6 +800,37 @@ BlendTree:
   m_UseAutomaticThresholds: 1
   m_NormalizedBlendValues: 0
   m_BlendType: 0
+--- !u!206 &206854462854706110
+BlendTree:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Blend Tree
+  m_Childs:
+  - serializedVersion: 2
+    m_Motion: {fileID: 206692708424922710}
+    m_Threshold: 0
+    m_Position: {x: 0, y: 0}
+    m_TimeScale: 1
+    m_CycleOffset: 0
+    m_DirectBlendParameter: movementMagnitude
+    m_Mirror: 0
+  - serializedVersion: 2
+    m_Motion: {fileID: 7400042, guid: a5a41eb454bd4124480bd9cf91ca0115, type: 3}
+    m_Threshold: 1
+    m_Position: {x: 0, y: 0}
+    m_TimeScale: 1
+    m_CycleOffset: 0
+    m_DirectBlendParameter: movementMagnitude
+    m_Mirror: 0
+  m_BlendParameter: climbUp
+  m_BlendParameterY: movementMagnitude
+  m_MinThreshold: 0
+  m_MaxThreshold: 1
+  m_UseAutomaticThresholds: 0
+  m_NormalizedBlendValues: 0
+  m_BlendType: 0
 --- !u!206 &206904659720857078
 BlendTree:
   m_ObjectHideFlags: 1
@@ -770,7 +901,7 @@ BlendTree:
   m_UseAutomaticThresholds: 0
   m_NormalizedBlendValues: 0
   m_BlendType: 0
---- !u!1101 &1101041393013350246
+--- !u!1101 &1101061463604504250
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
@@ -782,7 +913,7 @@ AnimatorStateTransition:
     m_ConditionEvent: climbing
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 1102042916418640090}
+  m_DstState: {fileID: 1102093837197383082}
   m_Solo: 0
   m_Mute: 0
   m_IsExit: 0
@@ -845,7 +976,7 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
---- !u!1101 &1101397711933660734
+--- !u!1101 &1101378010502448070
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
@@ -870,7 +1001,7 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
---- !u!1101 &1101449829382137954
+--- !u!1101 &1101506176426892004
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
@@ -882,12 +1013,12 @@ AnimatorStateTransition:
     m_ConditionEvent: climbing
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: 1102042916418640090}
+  m_DstState: {fileID: 1102093837197383082}
   m_Solo: 0
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0
+  m_TransitionDuration: 0.25
   m_TransitionOffset: 0
   m_ExitTime: 0.82708937
   m_HasExitTime: 0
@@ -945,6 +1076,31 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &1101995870991738984
+AnimatorStateTransition:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: fall
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 1102714876697769732}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.81250006
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &1102042916418640090
 AnimatorState:
   serializedVersion: 5
@@ -952,11 +1108,10 @@ AnimatorState:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: Climbing Motion
+  m_Name: Climbing Motion Old
   m_Speed: 1
   m_CycleOffset: 0
-  m_Transitions:
-  - {fileID: 1101397711933660734}
+  m_Transitions: []
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -967,6 +1122,33 @@ AnimatorState:
   m_CycleOffsetParameterActive: 0
   m_TimeParameterActive: 0
   m_Motion: {fileID: 206712803829767226}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1102 &1102093837197383082
+AnimatorState:
+  serializedVersion: 5
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Climbing Motion
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 1101378010502448070}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 206854462854706110}
   m_Tag: 
   m_SpeedParameter: 
   m_MirrorParameter: 
@@ -984,7 +1166,7 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 1101552698602373452}
-  - {fileID: 1101041393013350246}
+  - {fileID: 1101061463604504250}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -1013,7 +1195,7 @@ AnimatorState:
   m_Transitions:
   - {fileID: 1101158655575790752}
   - {fileID: 1101220630540281460}
-  - {fileID: 1101449829382137954}
+  - {fileID: 1101506176426892004}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -1046,7 +1228,10 @@ AnimatorStateMachine:
     m_Position: {x: 300, y: 156, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 1102042916418640090}
-    m_Position: {x: 540, y: 156, z: 0}
+    m_Position: {x: 612, y: 108, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 1102093837197383082}
+    m_Position: {x: 588, y: 192, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []
@@ -1054,7 +1239,7 @@ AnimatorStateMachine:
   m_StateMachineBehaviours: []
   m_AnyStatePosition: {x: 50, y: 20, z: 0}
   m_EntryPosition: {x: 50, y: 120, z: 0}
-  m_ExitPosition: {x: 648, y: 72, z: 0}
+  m_ExitPosition: {x: 636, y: 0, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
   m_DefaultState: {fileID: 1102730259130543242}
 --- !u!1109 &1109424961461271110

--- a/Assets/_Kyle/Characters/Protag/ProtagController v3.controller
+++ b/Assets/_Kyle/Characters/Protag/ProtagController v3.controller
@@ -113,6 +113,36 @@ BlendTree:
   m_UseAutomaticThresholds: 1
   m_NormalizedBlendValues: 0
   m_BlendType: 0
+--- !u!206 &206054192490831480
+BlendTree:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BlendTree
+  m_Childs: []
+  m_BlendParameter: movementMagnitude
+  m_BlendParameterY: movementMagnitude
+  m_MinThreshold: 0
+  m_MaxThreshold: 1
+  m_UseAutomaticThresholds: 1
+  m_NormalizedBlendValues: 0
+  m_BlendType: 0
+--- !u!206 &206101048011546010
+BlendTree:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BlendTree
+  m_Childs: []
+  m_BlendParameter: movementMagnitude
+  m_BlendParameterY: movementMagnitude
+  m_MinThreshold: 0
+  m_MaxThreshold: 1
+  m_UseAutomaticThresholds: 1
+  m_NormalizedBlendValues: 0
+  m_BlendType: 0
 --- !u!206 &206141273513786840
 BlendTree:
   m_ObjectHideFlags: 1
@@ -337,6 +367,21 @@ BlendTree:
   m_UseAutomaticThresholds: 1
   m_NormalizedBlendValues: 0
   m_BlendType: 0
+--- !u!206 &206451183691727238
+BlendTree:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: CLimbUp
+  m_Childs: []
+  m_BlendParameter: movementMagnitude
+  m_BlendParameterY: movementMagnitude
+  m_MinThreshold: 0
+  m_MaxThreshold: 1
+  m_UseAutomaticThresholds: 1
+  m_NormalizedBlendValues: 0
+  m_BlendType: 0
 --- !u!206 &206467139902878302
 BlendTree:
   m_ObjectHideFlags: 1
@@ -512,6 +557,14 @@ BlendTree:
     m_Motion: {fileID: 7400064, guid: a5a41eb454bd4124480bd9cf91ca0115, type: 3}
     m_Threshold: 15
     m_Position: {x: 0, y: 0.5}
+    m_TimeScale: 1
+    m_CycleOffset: 0
+    m_DirectBlendParameter: movementMagnitude
+    m_Mirror: 0
+  - serializedVersion: 2
+    m_Motion: {fileID: 206451183691727238}
+    m_Threshold: 0
+    m_Position: {x: 0, y: 0}
     m_TimeScale: 1
     m_CycleOffset: 0
     m_DirectBlendParameter: movementMagnitude

--- a/Assets/_Kyle/Characters/Protag/Scripts/Protag.cs
+++ b/Assets/_Kyle/Characters/Protag/Scripts/Protag.cs
@@ -18,6 +18,7 @@ namespace TCS.Characters
         public float aerialMovementStrength;
         public float aerialDrag;
         public float climbSpeed;
+        public float rotationOrientSpeed = 10;
         
         [SerializeField]
         private AnimationCurve compressionCurve;
@@ -126,6 +127,49 @@ namespace TCS.Characters
                 climbableWallInFront = false;
             }
         }
+
+        public bool checkLedgeAbove() {
+            // if we are at the base of a small cliff (or climbing at the top of a large cliff),
+            // we raycast down from ahead and above us to check the ground to climb onto.
+
+            float rayLength = 1;
+            Vector3 start = chestOffset * 2 + transform.localPosition;
+            Vector3 dir = Vector3.down;
+
+            RaycastHit hit;
+            Debug.DrawRay(start, dir * rayLength, Color.red);
+
+            // Is there a cliff above and in front?
+            if (Physics.Raycast(start, dir, out hit, rayLength, selfMask)) {
+
+                // is it a very flat surface, as opposed to a gradual slope?
+                if (Mathf.Abs(Vector3.Angle(hit.normal, Vector3.up)) < 10) {
+
+                    // are we oriented vertically enough that the climbing up ledge animation would be appropriate?
+                    if (Mathf.Abs(Vector3.Angle(modelTransform.forward, transform.forward)) < 15) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        public void lerpRotationToUpwards(){
+
+            // Orient the character so he is standing up
+
+            // lerping to base orientation can be ugly if we don't choose the right thing to lerp to.
+            // for example, if we're at -350 degrees rotation and want to get to 0, we should lerp to -360, not 0
+            float xSign = modelTransform.rotation.eulerAngles.x < 0 ? -1 : 1;
+            float rotationXTarget = (modelTransform.rotation.eulerAngles.x > 180 ? 360 : 0) * xSign;
+            float zSign = modelTransform.rotation.eulerAngles.z < 0 ? -1 : 1;
+            float rotationZTarget = (modelTransform.rotation.eulerAngles.z > 180 ? 360 : 0) * zSign;
+
+            modelTransform.rotation = Quaternion.Euler(
+                Mathf.Lerp(modelTransform.rotation.eulerAngles.x, rotationXTarget, Time.deltaTime * rotationOrientSpeed), 
+                modelTransform.rotation.eulerAngles.y,
+                Mathf.Lerp(modelTransform.rotation.eulerAngles.z, rotationZTarget, Time.deltaTime * rotationOrientSpeed));
+        }
         
         public PointNormalPair checkClimbingWall() {
 
@@ -146,6 +190,18 @@ namespace TCS.Characters
                 // there is a climbable wall above
                 hitPoints.Add(hit.point);
                 hitNormals.Add(hit.normal);
+                
+                // Is there a cliff above and in front?
+
+                // is it a very flat surface, as opposed to a gradual slope?
+                if (Mathf.Abs(Vector3.Angle(hit.normal, Vector3.up)) < 10) {
+                    Vector3 movementDir = Vector3.ProjectOnPlane(modelTransform.forward, groundNormal);
+                    // are we oriented vertically enough that the climbing up ledge animation would be appropriate?
+                    if (Mathf.Abs(Vector3.Angle(modelTransform.forward, movementDir)) < 15) {
+                        // we can climb up
+                        Debug.Log("Climb up ledge!");
+                    }
+                }
             }
 
             // check at the feet of the player
@@ -169,7 +225,7 @@ namespace TCS.Characters
             foreach (Vector3 norm in hitNormals) {
                 vecSum += norm;
             }
-            wallNormal = vecSum / hitNormals.Count;
+            wallNormal = hitNormals.Count > 0 ? vecSum / hitNormals.Count : Vector3.zero;
 
 
             // find the center of the points we can reach
@@ -177,7 +233,7 @@ namespace TCS.Characters
             foreach (Vector3 point in hitPoints) {
                 vecSum += point;
             }
-            Vector3 climbingTargetPos = vecSum / hitPoints.Count;
+            Vector3 climbingTargetPos = hitPoints.Count > 0 ? vecSum / hitPoints.Count : Vector3.zero;
 
             return new PointNormalPair(climbingTargetPos, wallNormal);
         }

--- a/Assets/_Kyle/Characters/Protag/Scripts/Protag.cs
+++ b/Assets/_Kyle/Characters/Protag/Scripts/Protag.cs
@@ -22,6 +22,8 @@ namespace TCS.Characters
         
         [SerializeField]
         private AnimationCurve compressionCurve;
+        [SerializeField]
+        private AnimationCurve climpUpCurve;
 
         [HideInInspector]
         public Rigidbody rb;
@@ -171,7 +173,7 @@ namespace TCS.Characters
                 Mathf.Lerp(modelTransform.rotation.eulerAngles.z, rotationZTarget, Time.deltaTime * rotationOrientSpeed));
         }
         
-        public PointNormalPair checkClimbingWall() {
+        public PointNormalActionTypeTuple checkClimbingWall() {
 
             Vector3 wallNormal = -modelTransform.forward;
 
@@ -199,7 +201,7 @@ namespace TCS.Characters
                     // are we oriented vertically enough that the climbing up ledge animation would be appropriate?
                     if (Mathf.Abs(Vector3.Angle(modelTransform.forward, movementDir)) < 15) {
                         // we can climb up
-                        Debug.Log("Climb up ledge!");
+                        return new PointNormalActionTypeTuple(hit.point, hit.normal, ClimbingContextualActionType.CLIMBUP);
                     }
                 }
             }
@@ -235,7 +237,7 @@ namespace TCS.Characters
             }
             Vector3 climbingTargetPos = hitPoints.Count > 0 ? vecSum / hitPoints.Count : Vector3.zero;
 
-            return new PointNormalPair(climbingTargetPos, wallNormal);
+            return new PointNormalActionTypeTuple(climbingTargetPos, wallNormal, ClimbingContextualActionType.CLIMBING);
         }
 
         public bool isMovingForward() {
@@ -266,6 +268,7 @@ namespace TCS.Characters
         }
 
         public float sampleCompressionCurve(float x) { return compressionCurve.Evaluate(x); }
+        public float sampleClimbUpCurve(float x) { return climpUpCurve.Evaluate(x); }
 
         public bool getGrounded() { return grounded; }
 

--- a/Assets/_Kyle/Characters/Protag/Scripts/States/Alive/Aerial/ProtagAerialState.cs
+++ b/Assets/_Kyle/Characters/Protag/Scripts/States/Alive/Aerial/ProtagAerialState.cs
@@ -15,6 +15,7 @@ namespace TCS.Characters
         public override void enter(ProtagInput input)
         {
             protag.setRootMotion(false);
+            protag.setAerial(true);
             protag.anim.SetBool("grounded", false);
             timer = 0;
         }
@@ -65,6 +66,8 @@ namespace TCS.Characters
                 protag.setAerial(true);
 
             protag.checkClimableWallInFront();
+            protag.checkGround();
+            protag.lerpRotationToUpwards();
             
             if (protag.getIsClimbableWallInFront() && protag.isMovingForward())
             {

--- a/Assets/_Kyle/Characters/Protag/Scripts/States/Alive/Climbing/ClimbingUpLedge.meta
+++ b/Assets/_Kyle/Characters/Protag/Scripts/States/Alive/Climbing/ClimbingUpLedge.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6e51b93194614f2499d7f80b594682ea
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Kyle/Characters/Protag/Scripts/States/Alive/Climbing/ClimbingUpLedge/ProtagClimbingUpLedgeState.cs
+++ b/Assets/_Kyle/Characters/Protag/Scripts/States/Alive/Climbing/ClimbingUpLedge/ProtagClimbingUpLedgeState.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TCS.Characters
+{
+    public class ProtagClimbingUpLedgeState : ProtagClimbingState
+    {
+        #region variables
+        private float timer;
+        #endregion
+
+        public override void enter(ProtagInput input)
+        {
+            base.enter(input);
+            protag.anim.SetBool("climbing", false);
+            //protag.anim.SetBool("land", true);
+            timer = 0;
+        }
+
+        public override void exit(ProtagInput input)
+        {
+            base.exit(input);
+            //protag.anim.SetBool("land", false);
+            protag.anim.SetFloat("climbUp", 0);
+        }
+
+        public override void runAnimation(ProtagInput input)
+        {
+            base.runAnimation(input);
+            timer += Time.deltaTime;
+            float sampleLocation = protag.sampleClimbUpCurve(timer);
+            protag.anim.SetFloat("climbUp", sampleLocation);
+        }
+
+        public override bool runLogic(ProtagInput input)
+        {
+            //if (base.runLogic(input))
+            //    return true;
+
+            if (timer > 2)
+            {
+                protag.newState<ProtagLocomotionState>();
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Assets/_Kyle/Characters/Protag/Scripts/States/Alive/Climbing/ClimbingUpLedge/ProtagClimbingUpLedgeState.cs.meta
+++ b/Assets/_Kyle/Characters/Protag/Scripts/States/Alive/Climbing/ClimbingUpLedge/ProtagClimbingUpLedgeState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 21bebed5d004c3a44a11ac3625ef6978
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Kyle/Characters/Protag/Scripts/States/Alive/Climbing/ProtagClimbingState.cs
+++ b/Assets/_Kyle/Characters/Protag/Scripts/States/Alive/Climbing/ProtagClimbingState.cs
@@ -47,12 +47,12 @@ namespace TCS.Characters
             Vector3 wallNormal = pnp.normal;
             Vector3 wallTargetPos = pnp.point;
 
-            if (wallNormal == null) {
-                Debug.LogError("Wall normal is null");
+            if (wallNormal == Vector3.zero) {
+                Debug.Log("Wall normal is zero... maybe an issue?");
                 return;
             }
             if (wallTargetPos == null) {
-                Debug.LogError("Target pos is null");
+                Debug.LogError("Target pos is zero");
                 return;
             }
 
@@ -73,7 +73,8 @@ namespace TCS.Characters
                 protag.modelTransform.rotation = Quaternion.Euler(angles.x, angles.y, 0);
 
                 // this code moves the player on the vertical axis. It should be handled by the root motion animations, but for some reason those aren't working.
-                transform.position += dirToMoveVertical * Time.deltaTime * normalizedInput.y * 1;
+                Vector3 yVec = dirToMoveVertical * Time.deltaTime * normalizedInput.y * 1;
+                transform.position = transform.position + yVec;
             }
 
             //set upwards animation/root motion
@@ -102,7 +103,7 @@ namespace TCS.Characters
                 }
             } else {
                 // there's no wall in front of us.
-                // this check probably shouldn't be here but it'll help test
+                // this check probably shouldn't be in this function but it'll help test at the least
                 protag.newState<ProtagFallingState>();
             }
         }
@@ -120,12 +121,11 @@ namespace TCS.Characters
                 protag.newState<ProtagFallingState>();
                 return true;
             }
-            else if (Vector3.Angle(wallNormal, Vector3.up) <= 15)
+            else if (Mathf.Abs(Vector3.Angle(wallNormal, Vector3.up)) <= 15)
             {
                 protag.newState<ProtagLocomotionState>();
                 return true;
             }
-
             return false;
         }
     }

--- a/Assets/_Kyle/Characters/Protag/Scripts/States/Alive/Grounded/ProtagGroundedState.cs
+++ b/Assets/_Kyle/Characters/Protag/Scripts/States/Alive/Grounded/ProtagGroundedState.cs
@@ -70,6 +70,8 @@ namespace TCS.Characters
             if (base.runLogic(input))
                 return true;
             
+
+            protag.lerpRotationToUpwards();
             // prevents sliding down slopes
             protag.checkGround();
             protag.rb.AddForce(-Vector3.ProjectOnPlane(Physics.gravity, protag.getGroundNormal()));


### PR DESCRIPTION
I left PlayerCameraController mostly as is, but I think we should replace it with the new PlayerCameraControllerQuat if everything looks good to you. It gets rid of the CamX, CamY, etc. and only has a intermediate camHolder transform, which makes rotation interpolation easier. Rotation interpolation might be important for things like targeting, cutscenes, and camera splines.